### PR TITLE
feat: supabase 테이블들 생성 후 그 테이블 컬럼정보를 타입으로 가져와 프로젝트 내에서 사용

### DIFF
--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,7 +1,23 @@
+import { notFound, redirect } from "next/navigation";
+
+import { getSupabaseServerClient } from "@/lib/supabase/server";
+
 const MyPage = async () => {
+  const supabase = await getSupabaseServerClient();
+  const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+  console.log(sessionData, sessionError);
+  if (!sessionData.session?.user?.id) redirect("/login");
+  const { data, error } = await supabase.from("profiles").select("*").eq("user_id", sessionData.session.user.id).single();
+  console.log(data, error);
+  if (!data) notFound();
   return (
     <div>
       MyPage
+      <div>
+        <pre>
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      </div>
     </div>
   );
 };

--- a/src/app/new/link/page.tsx
+++ b/src/app/new/link/page.tsx
@@ -5,12 +5,7 @@ import { useEffect, useState } from "react";
 
 import { LinkContainer } from "@/features/link/components/linkContainer";
 import { getSupabaseBrowserClient } from "@/lib/supabase/client";
-
-export interface Reward {
-  survey_id: number;
-  gacha_id: number;
-  possibility: boolean;
-}
+import { Reward } from "@/types";
 
 const LinkPage = () => {
   const supabase = getSupabaseBrowserClient();

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -9,23 +9,184 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
-      rewards: {
+      gachas: {
         Row: {
-          gacha_id: number | null;
-          possibility: boolean | null;
+          is_used: boolean | null;
+          profile_id: number;
+          received_at: string | null;
+          reward_id: number | null;
           survey_id: number;
         };
         Insert: {
-          gacha_id?: number | null;
-          possibility?: boolean | null;
-          survey_id?: number;
+          is_used?: boolean | null;
+          profile_id: number;
+          received_at?: string | null;
+          reward_id?: number | null;
+          survey_id: number;
         };
         Update: {
-          gacha_id?: number | null;
-          possibility?: boolean | null;
+          is_used?: boolean | null;
+          profile_id?: number;
+          received_at?: string | null;
+          reward_id?: number | null;
           survey_id?: number;
         };
+        Relationships: [
+          {
+            foreignKeyName: "gachas_profile_id_fkey";
+            columns: ["profile_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gachas_reward_id_fkey";
+            columns: ["reward_id"];
+            isOneToOne: false;
+            referencedRelation: "rewards";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gachas_survey_id_fkey";
+            columns: ["survey_id"];
+            isOneToOne: false;
+            referencedRelation: "surveys";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      profiles: {
+        Row: {
+          avatar_url: string | null;
+          bio: string | null;
+          created_at: string | null;
+          id: number;
+          user_id: string | null;
+          username: string | null;
+        };
+        Insert: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string | null;
+          id?: never;
+          user_id?: string | null;
+          username?: string | null;
+        };
+        Update: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string | null;
+          id?: never;
+          user_id?: string | null;
+          username?: string | null;
+        };
         Relationships: [];
+      };
+      profiles_surveys: {
+        Row: {
+          answers: Json | null;
+          participated_at: string | null;
+          profile_id: number;
+          survey_id: number;
+        };
+        Insert: {
+          answers?: Json | null;
+          participated_at?: string | null;
+          profile_id: number;
+          survey_id: number;
+        };
+        Update: {
+          answers?: Json | null;
+          participated_at?: string | null;
+          profile_id?: number;
+          survey_id?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "profiles_surveys_profile_id_fkey";
+            columns: ["profile_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "profiles_surveys_survey_id_fkey";
+            columns: ["survey_id"];
+            isOneToOne: false;
+            referencedRelation: "surveys";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      rewards: {
+        Row: {
+          created_at: string | null;
+          id: number;
+          is_claimed: boolean;
+          reward_type: string;
+          survey_id: number | null;
+        };
+        Insert: {
+          created_at?: string | null;
+          id?: never;
+          is_claimed?: boolean;
+          reward_type: string;
+          survey_id?: number | null;
+        };
+        Update: {
+          created_at?: string | null;
+          id?: never;
+          is_claimed?: boolean;
+          reward_type?: string;
+          survey_id?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "rewards_survey_id_fkey";
+            columns: ["survey_id"];
+            isOneToOne: false;
+            referencedRelation: "surveys";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      surveys: {
+        Row: {
+          created_at: string | null;
+          creator_id: number | null;
+          description: string | null;
+          id: number;
+          is_draft: boolean | null;
+          questions: Json | null;
+          title: string;
+        };
+        Insert: {
+          created_at?: string | null;
+          creator_id?: number | null;
+          description?: string | null;
+          id?: never;
+          is_draft?: boolean | null;
+          questions?: Json | null;
+          title: string;
+        };
+        Update: {
+          created_at?: string | null;
+          creator_id?: number | null;
+          description?: string | null;
+          id?: never;
+          is_draft?: boolean | null;
+          questions?: Json | null;
+          title?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "surveys_creator_id_fkey";
+            columns: ["creator_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
       };
     };
     Views: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,7 @@ export async function middleware(request: NextRequest) {
   const { supabase, response } = getSupabaseReqResClient(request);
   const { data } = await supabase.auth.getSession();
   const sessionUser = data?.session?.user;
+
   const searchParams = request.nextUrl.searchParams;
   const redirect = searchParams.get("redirect");
   const requestedPath = request.nextUrl.pathname;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
+export * from "./supabase";
+
+// TODO: 아래 mock data 타입들 삭제
 // 설문조사 관련 타입 정의
 export interface Question {
   id: number;

--- a/src/types/supabase/index.ts
+++ b/src/types/supabase/index.ts
@@ -1,0 +1,7 @@
+import { Database } from "@/lib/supabase/database.types";
+
+export type Profile = Database["public"]["Tables"]["profiles"]["Row"];
+export type Survey = Database["public"]["Tables"]["surveys"]["Row"];
+export type Reward = Database["public"]["Tables"]["rewards"]["Row"];
+export type Gacha = Database["public"]["Tables"]["gachas"]["Row"];
+export type Participation = Database["public"]["Tables"]["profiles_surveys"]["Row"];


### PR DESCRIPTION
### 변경사항
- Supabase 웹 스튜디오에서 테이블들을 생성한 후 로컬환경에서 그 테이블들의 타입을 당겨와 `database.types.ts` 파일로 만들어 사용합니다.
- 위 타입 파일 중 자주 쓰게 될 타입들은 따로 `supabase/types` 파일에 정리합니다.
- `/my` 페이지로 들어가면 현재 로그인 된 유저의 `profiles` 테이블 내 row 를 가져와 표시하도록 합니다.

#### 참고사항 (supabase 에 관심있는 경우)
`profiles` 테이블은 `auth.users` 테이블에 row 가 추가될 때마다 (즉 회원가입이 일어날 때마다) id 와 email 컬럼을 가져와 profiles.user_id 와 profiles.email 컬럼을 채우도록 trigger 를 생성했습니다. [참고자료](https://supabase.com/docs/guides/auth/managing-user-data#using-triggers)